### PR TITLE
fix: modules in a template should only display the right modules

### DIFF
--- a/app/Jobs/SetupAccount.php
+++ b/app/Jobs/SetupAccount.php
@@ -156,6 +156,7 @@ class SetupAccount implements ShouldQueue
             'name' => trans('app.module_avatar'),
             'type' => Module::TYPE_AVATAR,
             'can_be_deleted' => false,
+            'reserved_to_contact_information' => true,
         ]);
         (new AssociateModuleToTemplatePage())->execute([
             'account_id' => $this->user->account_id,
@@ -172,6 +173,7 @@ class SetupAccount implements ShouldQueue
             'name' => trans('app.module_names'),
             'type' => Module::TYPE_CONTACT_NAMES,
             'can_be_deleted' => false,
+            'reserved_to_contact_information' => true,
         ]);
         (new AssociateModuleToTemplatePage())->execute([
             'account_id' => $this->user->account_id,
@@ -188,6 +190,7 @@ class SetupAccount implements ShouldQueue
             'name' => trans('app.module_family_summary'),
             'type' => Module::TYPE_FAMILY_SUMMARY,
             'can_be_deleted' => false,
+            'reserved_to_contact_information' => true,
         ]);
         (new AssociateModuleToTemplatePage())->execute([
             'account_id' => $this->user->account_id,
@@ -204,6 +207,7 @@ class SetupAccount implements ShouldQueue
             'name' => trans('app.module_important_dates'),
             'type' => Module::TYPE_IMPORTANT_DATES,
             'can_be_deleted' => false,
+            'reserved_to_contact_information' => true,
         ]);
         (new AssociateModuleToTemplatePage())->execute([
             'account_id' => $this->user->account_id,
@@ -220,6 +224,7 @@ class SetupAccount implements ShouldQueue
             'name' => trans('app.module_gender_pronoun'),
             'type' => Module::TYPE_GENDER_PRONOUN,
             'can_be_deleted' => false,
+            'reserved_to_contact_information' => true,
         ]);
         (new AssociateModuleToTemplatePage())->execute([
             'account_id' => $this->user->account_id,
@@ -236,6 +241,7 @@ class SetupAccount implements ShouldQueue
             'name' => trans('app.module_labels'),
             'type' => Module::TYPE_LABELS,
             'can_be_deleted' => false,
+            'reserved_to_contact_information' => true,
         ]);
         (new AssociateModuleToTemplatePage())->execute([
             'account_id' => $this->user->account_id,
@@ -252,6 +258,7 @@ class SetupAccount implements ShouldQueue
             'name' => trans('app.module_companies'),
             'type' => Module::TYPE_COMPANY,
             'can_be_deleted' => false,
+            'reserved_to_contact_information' => true,
         ]);
         (new AssociateModuleToTemplatePage())->execute([
             'account_id' => $this->user->account_id,

--- a/domains/Settings/ManageTemplates/Services/CreateModule.php
+++ b/domains/Settings/ManageTemplates/Services/CreateModule.php
@@ -23,6 +23,7 @@ class CreateModule extends BaseService implements ServiceInterface
             'name' => 'required|string|max:255',
             'type' => 'nullable|string|max:255',
             'can_be_deleted' => 'required|boolean',
+            'reserved_to_contact_information' => 'nullable|boolean',
         ];
     }
 
@@ -54,6 +55,7 @@ class CreateModule extends BaseService implements ServiceInterface
             'name' => $data['name'],
             'type' => $this->valueOrNull($data, 'type'),
             'can_be_deleted' => $data['can_be_deleted'],
+            'reserved_to_contact_information' => $this->valueOrFalse($data, 'reserved_to_contact_information'),
         ]);
 
         return $this->module;

--- a/domains/Settings/ManageTemplates/Web/ViewHelpers/PersonalizeTemplatePageShowViewHelper.php
+++ b/domains/Settings/ManageTemplates/Web/ViewHelpers/PersonalizeTemplatePageShowViewHelper.php
@@ -10,9 +10,12 @@ class PersonalizeTemplatePageShowViewHelper
     public static function data(TemplatePage $templatePage): array
     {
         $allModules = $templatePage->template->account->modules()
+            ->where('reserved_to_contact_information', $templatePage->type === TemplatePage::TYPE_CONTACT)
             ->orderBy('name', 'asc')
             ->get();
 
+        // if the current page is not about contact information, we should not
+        // include the modules that should only on the contact information page
         $modulesInPage = $templatePage->modules()
             ->orderBy('position', 'asc')
             ->get();

--- a/resources/js/Pages/Settings/Personalize/Templates/Partials/Modules.vue
+++ b/resources/js/Pages/Settings/Personalize/Templates/Partials/Modules.vue
@@ -2,11 +2,15 @@
   <div>
     <div class="mb-4 mt-8 items-center justify-between border-b pb-3 sm:mt-0 sm:flex">
       <h3>{{ $t('settings.personalize_template_show_module_title') }}</h3>
+
+      <!-- add module -->
       <pretty-button
         v-if="!addModuleModalShown && moduleLoaded"
         :text="$t('settings.personalize_template_show_module_cta')"
         :icon="'plus'"
         @click="showModuleModal" />
+
+      <!-- cancel button -->
       <pretty-button
         v-if="addModuleModalShown && moduleLoaded"
         :text="$t('app.cancel')"


### PR DESCRIPTION
You fool, don't forget these steps:

- [ ] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
