### PR TITLE
build: use cache when building from dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ docker run -p 8080:80 ghcr.io/monicahq/monica-next:main
 
 This runs the image locally on port 8080 and using sqlite. You can then access the application at http://localhost:8080.
 
-
 ### Configuration
 
 Note that you'll need to setup a mail mailer to be able to register a user.
@@ -40,11 +39,6 @@ docker run -p 8080:80 -e MAIL_MAILER=log ghcr.io/monicahq/monica-next:main
 
 For more complex scenario (database setup, queue, etc.) see https://github.com/monicahq/docker/tree/main/.examples
 
+### Build it yourself
 
-### Build it
-
-You can also build your image locally with:
-
-```sh
-docker build -t monica-next -f scripts/docker/Dockerfile .
-```
+You can also build your image locally using `yarn docker:build` and run it with `yarn docker:run`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "format": "prettier --write '**/*.{js,vue,css,scss}'",
     "pretest": "DB_CONNECTION=testing php artisan migrate:fresh && DB_CONNECTION=testing php artisan db:seed",
     "posttest": "vendor/bin/phpstan analyse && vendor/bin/psalm",
-    "test": "vendor/bin/phpunit"
+    "test": "vendor/bin/phpunit",
+    "docker:build": "docker build --cache-from monica-next -t monica-next -f scripts/docker/Dockerfile . && docker image prune -f",
+    "docker:run": "docker run --name monica -p 8080:80 -e MAIL_MAILER=log monica-next"
   },
   "devDependencies": {
     "@inertiajs/inertia": "^0.11.0",


### PR DESCRIPTION
This PR optimizes the build process slightly, making local development easier. Would be great if I could get some help with docker-sync or volumes setup on this. New to the Laravel dev loop.