### PR TITLE
feat: add cron table

### DIFF
--- a/app/Console/Commands/TestReminders.php
+++ b/app/Console/Commands/TestReminders.php
@@ -58,11 +58,11 @@ class TestReminders extends Command
             }
 
             try {
-                (new RescheduleContactReminderForChannel())->execute([
+                (new RescheduleContactReminderForChannel([
                     'contact_reminder_id' => $scheduledReminder->contact_reminder_id,
                     'user_notification_channel_id' => $scheduledReminder->user_notification_channel_id,
                     'contact_reminder_scheduled_id' => $scheduledReminder->id,
-                ]);
+                ]))->handle();
             } catch (ModelNotFoundException) {
                 continue;
             }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,25 +2,13 @@
 
 namespace App\Console;
 
+use App\Console\Scheduling\CronEvent;
 use App\Domains\Contact\ManageReminders\Jobs\ProcessScheduledContactReminders;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
 class Kernel extends ConsoleKernel
 {
-    /**
-     * Define the application's command schedule.
-     *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
-     * @return void
-     * @codeCoverageIgnore
-     */
-    protected function schedule(Schedule $schedule)
-    {
-        $schedule->job(new ProcessScheduledContactReminders())->everyMinute();
-        $schedule->command('telescope:prune')->daily();
-    }
-
     /**
      * Register the commands for the application.
      *
@@ -31,5 +19,54 @@ class Kernel extends ConsoleKernel
         $this->load(__DIR__.'/Commands');
 
         require base_path('routes/console.php');
+    }
+
+    /**
+     * Define the application's command schedule.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     */
+    protected function schedule(Schedule $schedule)
+    {
+        $this->scheduleCommand($schedule, 'telescope:prune', 'daily');
+        $this->scheduleJob($schedule, ProcessScheduledContactReminders::class, 'minutes', 1);
+    }
+
+    /**
+     * Define a new schedule command with a frequency.
+     *
+     * @codeCoverageIgnore
+     */
+    private function scheduleCommand(Schedule $schedule, string $command, string $frequency, mixed ...$params)
+    {
+        $this->scheduleAction($schedule, $command, $frequency, $params);
+    }
+
+    /**
+     * Define a new schedule command with a frequency.
+     *
+     * @codeCoverageIgnore
+     */
+    private function scheduleJob(Schedule $schedule, string $job, string $frequency, mixed ...$params)
+    {
+        $this->scheduleAction($schedule, $job, $frequency, $params, 'job');
+    }
+
+    /**
+     * Define a new schedule.
+     *
+     * @codeCoverageIgnore
+     */
+    private function scheduleAction(Schedule $schedule, string $command, string $frequency, array $params, string $action = 'command')
+    {
+        $schedule->$action($command)->when(function () use ($command, $frequency, $params) {
+            $event = CronEvent::command($command);
+            if ($frequency) {
+                $event = $event->{$frequency}(...$params);
+            }
+
+            return $event->isDue();
+        });
     }
 }

--- a/app/Console/Scheduling/CronEvent.php
+++ b/app/Console/Scheduling/CronEvent.php
@@ -123,14 +123,14 @@ class CronEvent
             $t = $this->cron->last_run;
 
             if ($this->minutes !== 0) {
-                $next_run = Carbon::create($t->year, $t->month, $t->day, $t->hour, (int) floor($t->minute / $this->minutes) * $this->minutes, 0)
+                $nextRun = Carbon::create($t->year, $t->month, $t->day, $t->hour, (int) floor($t->minute / $this->minutes) * $this->minutes, 0)
                                     ->addMinutes($this->minutes);
             } elseif ($this->days !== 0) {
-                $next_run = Carbon::create($t->year, $t->month, (int) floor($t->day / $this->days) * $this->days, 0, 0, 0)
+                $nextRun = Carbon::create($t->year, $t->month, (int) floor($t->day / $this->days) * $this->days, 0, 0, 0)
                                     ->addDays($this->days);
             }
 
-            if (! isset($next_run) || $next_run > $now) {
+            if (! isset($nextRun) || $nextRun > $now) {
                 return false;
             }
         }

--- a/app/Console/Scheduling/CronEvent.php
+++ b/app/Console/Scheduling/CronEvent.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Console\Scheduling;
+
+use App\Models\Instance\Cron;
+use Carbon\Carbon;
+
+class CronEvent
+{
+    /**
+     * The cron model.
+     *
+     * @var Cron
+     */
+    private $cron;
+
+    /**
+     * Frequency to run the command in minutes.
+     *
+     * @var int
+     */
+    private $minutes = 1;
+
+    /**
+     * Frequency to run the command in days.
+     *
+     * @var int
+     */
+    private $days = 0;
+
+    public function __construct(Cron $cron)
+    {
+        $this->cron = $cron;
+    }
+
+    /**
+     * Get the command.
+     *
+     * @param  string  $command
+     * @return self
+     */
+    public static function command(string $command): self
+    {
+        /** @var \App\Models\Instance\Cron $cron */
+        $cron = Cron::firstOrCreate(['command' => $command]);
+
+        return new self($cron);
+    }
+
+    /**
+     * Get current Cron.
+     *
+     * @return Cron
+     */
+    public function cron()
+    {
+        return $this->cron;
+    }
+
+    /**
+     * Run the command once per hour.
+     *
+     * @return self
+     */
+    public function hourly(): self
+    {
+        $this->minutes = 60;
+        $this->days = 0;
+
+        return $this;
+    }
+
+    /**
+     * Run the command once per day.
+     *
+     * @return self
+     */
+    public function daily(): self
+    {
+        $this->minutes = 0;
+        $this->days = 1;
+
+        return $this;
+    }
+
+    /**
+     * Run the command once a week.
+     *
+     * @return self
+     */
+    public function weekly(): self
+    {
+        $this->minutes = 0;
+        $this->days = 7;
+
+        return $this;
+    }
+
+    /**
+     * Run the command every $minutes.
+     *
+     * @param  int  $minutes
+     * @return self
+     */
+    public function minutes(int $minutes): self
+    {
+        $this->minutes = $minutes;
+        $this->days = 0;
+
+        return $this;
+    }
+
+    /**
+     * Test if the command is due to run.
+     *
+     * @return bool
+     */
+    public function isDue(): bool
+    {
+        $now = now();
+
+        if ($this->cron->last_run !== null) {
+            $t = $this->cron->last_run;
+
+            if ($this->minutes !== 0) {
+                $next_run = Carbon::create($t->year, $t->month, $t->day, $t->hour, (int) floor($t->minute / $this->minutes) * $this->minutes, 0)
+                                    ->addMinutes($this->minutes);
+            } elseif ($this->days !== 0) {
+                $next_run = Carbon::create($t->year, $t->month, (int) floor($t->day / $this->days) * $this->days, 0, 0, 0)
+                                    ->addDays($this->days);
+            }
+
+            if (! isset($next_run) || $next_run > $now) {
+                return false;
+            }
+        }
+
+        $this->cron->update(['last_run' => $now]);
+
+        return true;
+    }
+}

--- a/app/Console/Scheduling/CronEvent.php
+++ b/app/Console/Scheduling/CronEvent.php
@@ -119,8 +119,8 @@ class CronEvent
     {
         $now = now();
 
-        if ($this->cron->last_run !== null) {
-            $t = $this->cron->last_run;
+        if ($this->cron->last_run_at !== null) {
+            $t = $this->cron->last_run_at;
 
             if ($this->minutes !== 0) {
                 $nextRun = Carbon::create($t->year, $t->month, $t->day, $t->hour, (int) floor($t->minute / $this->minutes) * $this->minutes, 0)
@@ -135,7 +135,7 @@ class CronEvent
             }
         }
 
-        $this->cron->update(['last_run' => $now]);
+        $this->cron->update(['last_run_at' => $now]);
 
         return true;
     }

--- a/app/Domains/Contact/ManageReminders/Jobs/ProcessScheduledContactReminders.php
+++ b/app/Domains/Contact/ManageReminders/Jobs/ProcessScheduledContactReminders.php
@@ -13,25 +13,12 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 
 class ProcessScheduledContactReminders implements ShouldQueue
 {
-    use Dispatchable;
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
-    /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-    }
+    use Dispatchable, InteractsWithQueue, Queueable;
 
     /**
      * Execute the job.
@@ -72,11 +59,13 @@ class ProcessScheduledContactReminders implements ShouldQueue
             $this->updateScheduledContactReminderTriggeredAt($scheduledReminder->id);
             $this->updateNumberOfTimesTriggered($scheduledReminder->contact_reminder_id);
 
-            (new RescheduleContactReminderForChannel())->execute([
-                'contact_reminder_id' => $scheduledReminder->contact_reminder_id,
-                'user_notification_channel_id' => $scheduledReminder->user_notification_channel_id,
-                'contact_reminder_scheduled_id' => $scheduledReminder->id,
-            ]);
+            $this->appendToChain(
+                new RescheduleContactReminderForChannel([
+                    'contact_reminder_id' => $scheduledReminder->contact_reminder_id,
+                    'user_notification_channel_id' => $scheduledReminder->user_notification_channel_id,
+                    'contact_reminder_scheduled_id' => $scheduledReminder->id,
+                ])
+            );
         }
     }
 

--- a/app/Domains/Contact/ManageReminders/Services/RescheduleContactReminderForChannel.php
+++ b/app/Domains/Contact/ManageReminders/Services/RescheduleContactReminderForChannel.php
@@ -5,18 +5,16 @@ namespace App\Domains\Contact\ManageReminders\Services;
 use App\Interfaces\ServiceInterface;
 use App\Models\ContactReminder;
 use App\Models\UserNotificationChannel;
-use App\Services\BaseService;
+use App\Services\QueuableService;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\DB;
 
-class RescheduleContactReminderForChannel extends BaseService implements ServiceInterface
+class RescheduleContactReminderForChannel extends QueuableService implements ServiceInterface
 {
     private UserNotificationChannel $userNotificationChannel;
 
     private ContactReminder $contactReminder;
-
-    private array $data;
 
     private Carbon $upcomingDate;
 

--- a/app/Domains/Settings/CreateAccount/Jobs/SetupAccount.php
+++ b/app/Domains/Settings/CreateAccount/Jobs/SetupAccount.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Domains\Settings\CreateAccount\Services;
+namespace App\Domains\Settings\CreateAccount\Jobs;
 
 use App\Domains\Settings\ManageActivityTypes\Services\CreateActivityType;
 use App\Domains\Settings\ManageAddressTypes\Services\CreateAddressType;

--- a/app/Domains/Settings/CreateAccount/Services/CreateAccount.php
+++ b/app/Domains/Settings/CreateAccount/Services/CreateAccount.php
@@ -3,6 +3,7 @@
 namespace App\Domains\Settings\CreateAccount\Services;
 
 use App\Actions\Fortify\PasswordValidationRules;
+use App\Domains\Settings\CreateAccount\Jobs\SetupAccount;
 use App\Interfaces\ServiceInterface;
 use App\Models\Account;
 use App\Models\User;

--- a/app/Models/Instance/Cron.php
+++ b/app/Models/Instance/Cron.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Instance;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Cron extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<string>
+     */
+    protected $fillable = [
+        'command',
+        'last_run',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'last_run' => 'datetime',
+    ];
+}

--- a/app/Models/Instance/Cron.php
+++ b/app/Models/Instance/Cron.php
@@ -16,7 +16,7 @@ class Cron extends Model
      */
     protected $fillable = [
         'command',
-        'last_run',
+        'last_run_at',
     ];
 
     /**
@@ -25,6 +25,6 @@ class Cron extends Model
      * @var array<string, string>
      */
     protected $casts = [
-        'last_run' => 'datetime',
+        'last_run_at' => 'datetime',
     ];
 }

--- a/app/Models/Instance/Cron.php
+++ b/app/Models/Instance/Cron.php
@@ -2,10 +2,13 @@
 
 namespace App\Models\Instance;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Cron extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/database/factories/Instance/CronFactory.php
+++ b/database/factories/Instance/CronFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Database\Factories;
+namespace Database\Factories\Instance;
 
 use App\Models\Instance\Cron;
 use Carbon\Carbon;

--- a/database/factories/Instance/CronFactory.php
+++ b/database/factories/Instance/CronFactory.php
@@ -24,7 +24,7 @@ class CronFactory extends Factory
     {
         return [
             'command' => $this->faker->word,
-            'last_run' => Carbon::now(),
+            'last_run_at' => Carbon::now(),
         ];
     }
 }

--- a/database/factories/Instance/CronFactory.php
+++ b/database/factories/Instance/CronFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Instance\Cron;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CronFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
+     */
+    protected $model = Cron::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'command' => $this->faker->word,
+            'last_run' => Carbon::now(),
+        ];
+    }
+}

--- a/database/migrations/2019_05_05_194746_add_cron_schedule.php
+++ b/database/migrations/2019_05_05_194746_add_cron_schedule.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('crons', function (Blueprint $table) {
             $table->increments('id');
             $table->string('command')->unique();
-            $table->timestamp('last_run');
+            $table->timestamp('last_run_at');
             $table->timestamps();
         });
     }

--- a/database/migrations/2019_05_05_194746_add_cron_schedule.php
+++ b/database/migrations/2019_05_05_194746_add_cron_schedule.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('crons', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('command')->unique();
+            $table->timestamp('last_run');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('crons');
+    }
+};

--- a/tests/Unit/Commands/Scheduling/CronEventTest.php
+++ b/tests/Unit/Commands/Scheduling/CronEventTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Commands\Scheduling;
+
+use App\Console\Scheduling\CronEvent;
+use App\Models\Instance\Cron;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class CronEventTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_get_the_right_command()
+    {
+        $cron = factory(Cron::class)->create();
+
+        $event = CronEvent::command($cron->command);
+
+        $this->assertEquals($event->cron()->id, $cron->id);
+    }
+
+    /** @test */
+    public function now_not_due()
+    {
+        $cron = factory(Cron::class)->create();
+        $event = new CronEvent($cron);
+
+        $this->assertFalse($event->isDue());
+    }
+
+    /** @test */
+    public function next_minute_is_due()
+    {
+        Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 0, 0));
+
+        $cron = factory(Cron::class)->create();
+        $event = new CronEvent($cron);
+
+        $this->assertFalse($event->isDue());
+
+        Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 1, 0));
+
+        $this->assertTrue($event->isDue());
+
+        $this->assertDatabaseHas('crons', [
+            'command' => $cron->command,
+            'last_run' => '2019-05-01 07:01:00',
+        ]);
+    }
+
+    /** @test */
+    public function hourly_cron()
+    {
+        Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 0, 0));
+
+        $cron = factory(Cron::class)->create();
+        $event = new CronEvent($cron);
+        $event->hourly();
+
+        $this->assertFalse($event->isDue());
+
+        Carbon::setTestNow(Carbon::create(2019, 5, 1, 8, 22, 0));
+
+        $this->assertTrue($event->isDue());
+
+        $this->assertDatabaseHas('crons', [
+            'command' => $cron->command,
+            'last_run' => '2019-05-01 08:22:00',
+        ]);
+
+        Carbon::setTestNow(Carbon::create(2019, 5, 1, 8, 59, 0));
+
+        $this->assertFalse($event->isDue());
+
+        Carbon::setTestNow(Carbon::create(2019, 5, 1, 9, 01, 0));
+
+        $this->assertTrue($event->isDue());
+
+        $this->assertDatabaseHas('crons', [
+            'command' => $cron->command,
+            'last_run' => '2019-05-01 09:01:00',
+        ]);
+    }
+
+    /** @test */
+    public function daily_cron()
+    {
+        Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 0, 0));
+
+        $cron = factory(Cron::class)->create();
+        $event = new CronEvent($cron);
+        $event->daily();
+
+        Carbon::setTestNow(Carbon::create(2019, 5, 2, 8, 10, 0));
+
+        $this->assertTrue($event->isDue());
+
+        $this->assertDatabaseHas('crons', [
+            'command' => $cron->command,
+            'last_run' => '2019-05-02 08:10:00',
+        ]);
+
+        Carbon::setTestNow(Carbon::create(2019, 5, 2, 10, 0, 0));
+
+        $this->assertFalse($event->isDue());
+
+        Carbon::setTestNow(Carbon::create(2019, 5, 3, 0, 0, 0));
+
+        $this->assertTrue($event->isDue());
+
+        $this->assertDatabaseHas('crons', [
+            'command' => $cron->command,
+            'last_run' => '2019-05-03 00:00:00',
+        ]);
+    }
+}

--- a/tests/Unit/Commands/Scheduling/CronEventTest.php
+++ b/tests/Unit/Commands/Scheduling/CronEventTest.php
@@ -15,7 +15,7 @@ class CronEventTest extends TestCase
     /** @test */
     public function it_get_the_right_command()
     {
-        $cron = factory(Cron::class)->create();
+        $cron = Cron::factory()->create();
 
         $event = CronEvent::command($cron->command);
 
@@ -25,7 +25,7 @@ class CronEventTest extends TestCase
     /** @test */
     public function now_not_due()
     {
-        $cron = factory(Cron::class)->create();
+        $cron = Cron::factory()->create();
         $event = new CronEvent($cron);
 
         $this->assertFalse($event->isDue());
@@ -36,7 +36,7 @@ class CronEventTest extends TestCase
     {
         Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 0, 0));
 
-        $cron = factory(Cron::class)->create();
+        $cron = Cron::factory()->create();
         $event = new CronEvent($cron);
 
         $this->assertFalse($event->isDue());
@@ -56,7 +56,7 @@ class CronEventTest extends TestCase
     {
         Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 0, 0));
 
-        $cron = factory(Cron::class)->create();
+        $cron = Cron::factory()->create();
         $event = new CronEvent($cron);
         $event->hourly();
 
@@ -90,7 +90,7 @@ class CronEventTest extends TestCase
     {
         Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 0, 0));
 
-        $cron = factory(Cron::class)->create();
+        $cron = Cron::factory()->create();
         $event = new CronEvent($cron);
         $event->daily();
 

--- a/tests/Unit/Commands/Scheduling/CronEventTest.php
+++ b/tests/Unit/Commands/Scheduling/CronEventTest.php
@@ -47,7 +47,7 @@ class CronEventTest extends TestCase
 
         $this->assertDatabaseHas('crons', [
             'command' => $cron->command,
-            'last_run' => '2019-05-01 07:01:00',
+            'last_run_at' => '2019-05-01 07:01:00',
         ]);
     }
 
@@ -68,7 +68,7 @@ class CronEventTest extends TestCase
 
         $this->assertDatabaseHas('crons', [
             'command' => $cron->command,
-            'last_run' => '2019-05-01 08:22:00',
+            'last_run_at' => '2019-05-01 08:22:00',
         ]);
 
         Carbon::setTestNow(Carbon::create(2019, 5, 1, 8, 59, 0));
@@ -81,7 +81,7 @@ class CronEventTest extends TestCase
 
         $this->assertDatabaseHas('crons', [
             'command' => $cron->command,
-            'last_run' => '2019-05-01 09:01:00',
+            'last_run_at' => '2019-05-01 09:01:00',
         ]);
     }
 
@@ -100,7 +100,7 @@ class CronEventTest extends TestCase
 
         $this->assertDatabaseHas('crons', [
             'command' => $cron->command,
-            'last_run' => '2019-05-02 08:10:00',
+            'last_run_at' => '2019-05-02 08:10:00',
         ]);
 
         Carbon::setTestNow(Carbon::create(2019, 5, 2, 10, 0, 0));
@@ -113,7 +113,7 @@ class CronEventTest extends TestCase
 
         $this->assertDatabaseHas('crons', [
             'command' => $cron->command,
-            'last_run' => '2019-05-03 00:00:00',
+            'last_run_at' => '2019-05-03 00:00:00',
         ]);
     }
 }

--- a/tests/Unit/Domains/Contact/ManageReminders/Services/RescheduleContactReminderForChannelTest.php
+++ b/tests/Unit/Domains/Contact/ManageReminders/Services/RescheduleContactReminderForChannelTest.php
@@ -37,11 +37,11 @@ class RescheduleContactReminderForChannelTest extends TestCase
             'scheduled_at' => '2018-01-01 00:00:00',
         ]);
 
-        (new RescheduleContactReminderForChannel())->execute([
+        (new RescheduleContactReminderForChannel([
             'contact_reminder_id' => $contactReminder->id,
             'user_notification_channel_id' => $channel->id,
             'contact_reminder_scheduled_id' => $id,
-        ]);
+        ]))->handle();
 
         $this->assertDatabaseMissing('contact_reminder_scheduled', [
             'user_notification_channel_id' => $channel->id,
@@ -72,11 +72,11 @@ class RescheduleContactReminderForChannelTest extends TestCase
             'scheduled_at' => '2018-01-01 00:00:00',
         ]);
 
-        (new RescheduleContactReminderForChannel())->execute([
+        (new RescheduleContactReminderForChannel([
             'contact_reminder_id' => $contactReminder->id,
             'user_notification_channel_id' => $channel->id,
             'contact_reminder_scheduled_id' => $id,
-        ]);
+        ]))->handle();
 
         $this->assertDatabaseHas('contact_reminder_scheduled', [
             'user_notification_channel_id' => $channel->id,
@@ -107,11 +107,11 @@ class RescheduleContactReminderForChannelTest extends TestCase
             'scheduled_at' => '2018-01-01 00:00:00',
         ]);
 
-        (new RescheduleContactReminderForChannel())->execute([
+        (new RescheduleContactReminderForChannel([
             'contact_reminder_id' => $contactReminder->id,
             'user_notification_channel_id' => $channel->id,
             'contact_reminder_scheduled_id' => $id,
-        ]);
+        ]))->handle();
 
         $this->assertDatabaseHas('contact_reminder_scheduled', [
             'user_notification_channel_id' => $channel->id,
@@ -142,11 +142,11 @@ class RescheduleContactReminderForChannelTest extends TestCase
             'scheduled_at' => '2018-01-01 00:00:00',
         ]);
 
-        (new RescheduleContactReminderForChannel())->execute([
+        (new RescheduleContactReminderForChannel([
             'contact_reminder_id' => $contactReminder->id,
             'user_notification_channel_id' => $channel->id,
             'contact_reminder_scheduled_id' => $id,
-        ]);
+        ]))->handle();
 
         $this->assertDatabaseHas('contact_reminder_scheduled', [
             'user_notification_channel_id' => $channel->id,
@@ -180,11 +180,11 @@ class RescheduleContactReminderForChannelTest extends TestCase
             'scheduled_at' => '2018-01-01 00:00:00',
         ]);
 
-        (new RescheduleContactReminderForChannel())->execute([
+        (new RescheduleContactReminderForChannel([
             'contact_reminder_id' => $contactReminder->id,
             'user_notification_channel_id' => $channel->id,
             'contact_reminder_scheduled_id' => $id,
-        ]);
+        ]))->handle();
 
         $this->assertDatabaseMissing('contact_reminder_scheduled', [
             'user_notification_channel_id' => $channel->id,

--- a/tests/Unit/Domains/Settings/CreateAccount/Services/CreateAccountTest.php
+++ b/tests/Unit/Domains/Settings/CreateAccount/Services/CreateAccountTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Domains\Settings\CreateAccount\Services;
 
+use App\Domains\Settings\CreateAccount\Jobs\SetupAccount;
 use App\Domains\Settings\CreateAccount\Services\CreateAccount;
-use App\Domains\Settings\CreateAccount\Services\SetupAccount;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Queue;

--- a/tests/Unit/Domains/Settings/CreateAccount/Services/SetupAccountTest.php
+++ b/tests/Unit/Domains/Settings/CreateAccount/Services/SetupAccountTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Domains\Settings\CreateAccount\Services;
 
-use App\Domains\Settings\CreateAccount\Services\SetupAccount;
+use App\Domains\Settings\CreateAccount\Jobs\SetupAccount;
 use App\Models\Currency;
 use App\Models\RelationshipGroupType;
 use Illuminate\Foundation\Testing\DatabaseTransactions;


### PR DESCRIPTION
Laravel needs schedules to run every minutes, but it's not always possible. This fix it somehow.