### PR TITLE
fix: fix contact name attribute

### DIFF
--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -353,13 +353,7 @@ class Contact extends Model
     protected function name(): Attribute
     {
         return Attribute::make(
-            get: function ($value, $attributes) {
-                if (Auth::check()) {
-                    return NameHelper::formatContactName(Auth::user(), $this);
-                }
-
-                return $attributes['first_name'].' '.$attributes['last_name'];
-            }
+            get: fn () => NameHelper::formatContactName(Auth::user(), $this)
         );
     }
 


### PR DESCRIPTION
There is no scenario I can imagine where we would get the `name` attribute if the user is not authenticated