### PR TITLE
fix: fix contact information without a protocol

### DIFF
--- a/app/Domains/Contact/ManageContactInformation/Web/ViewHelpers/ModuleContactInformationViewHelper.php
+++ b/app/Domains/Contact/ManageContactInformation/Web/ViewHelpers/ModuleContactInformationViewHelper.php
@@ -41,7 +41,9 @@ class ModuleContactInformationViewHelper
         return [
             'id' => $info->id,
             'label' => $info->name,
-            'data' => $info->contactInformationType->protocol ? $info->contactInformationType->protocol.$info->data : $info->data,
+            'protocol' => $info->contactInformationType->protocol,
+            'data' => $info->data,
+            'data_with_protocol' => $info->contactInformationType->protocol ? $info->contactInformationType->protocol.$info->data : $info->data,
             'contact_information_type' => [
                 'id' => $info->contactInformationType->id,
                 'name' => $info->contactInformationType->name,

--- a/resources/js/Shared/Modules/ContactInformation.vue
+++ b/resources/js/Shared/Modules/ContactInformation.vue
@@ -48,7 +48,7 @@
             :type="'text'"
             :autofocus="true"
             :input-class="'block w-full'"
-            :required="false"
+            :required="true"
             :autocomplete="false"
             :maxlength="255"
             @esc-key-pressed="addContactInformationModalShown = false" />
@@ -81,7 +81,10 @@
           class="item-list border-b border-gray-200 hover:bg-slate-50 dark:border-gray-700 dark:bg-slate-900 hover:dark:bg-slate-800">
           <!-- contact information -->
           <div v-if="editedContactInformationId != info.id" class="flex items-center justify-between px-3 py-2">
-            <a :href="info.data" class="text-blue-500 hover:underline">{{ info.label }} </a>
+            <div>
+              <a :href="info.data_with_protocol" class="text-blue-500 hover:underline">{{ info.data }}</a>
+              <span class="ml-2 text-xs text-gray-500">({{ info.label }})</span>
+            </div>
 
             <!-- actions -->
             <ul class="text-sm">

--- a/resources/js/Shared/Modules/ContactInformation.vue
+++ b/resources/js/Shared/Modules/ContactInformation.vue
@@ -200,7 +200,7 @@ export default {
       this.addContactInformationModalShown = true;
       this.form.errors = [];
       this.form.data = '';
-      this.form.contact_information_type_id = 0;
+      this.form.contact_information_type_id = this.data.contact_information_types[0].id;
 
       this.$nextTick(() => {
         this.$refs.newData.focus();

--- a/tests/Unit/Domains/Contact/ManageContactInformation/Web/ViewHelpers/ModuleContactInformationViewHelperTest.php
+++ b/tests/Unit/Domains/Contact/ManageContactInformation/Web/ViewHelpers/ModuleContactInformationViewHelperTest.php
@@ -78,7 +78,9 @@ class ModuleContactInformationViewHelperTest extends TestCase
             [
                 'id' => $info->id,
                 'label' => 'Facebook shit',
-                'data' => 'mailto:'.$info->data,
+                'protocol' => 'mailto:',
+                'data' => $info->data,
+                'data_with_protocol' => 'mailto:'.$info->data,
                 'contact_information_type' => [
                     'id' => $type->id,
                     'name' => 'Facebook shit',


### PR DESCRIPTION
close #344 #343

- data is now required (don't know why it was not)
- we always display the data without the protocol now
- information type is now displayed