### PR TITLE
refactor: change link for docs

### DIFF
--- a/config/monica.php
+++ b/config/monica.php
@@ -85,7 +85,7 @@ return [
     |
     */
 
-    'help_center_url' => 'https://regis-freyd.gitbook.io/docs/',
+    'help_center_url' => 'https://docs.monicahq.com/',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
We now use https://docs.monicahq.com