### PR TITLE
fix: fix `sortByCollator` collection macro return keys

### DIFF
--- a/app/Helpers/CollectionHelper.php
+++ b/app/Helpers/CollectionHelper.php
@@ -37,7 +37,7 @@ class CollectionHelper
             $results[$key] = $collect->get($key);
         }
 
-        return new Collection($results);
+        return new Collection(array_values($results));
     }
 
     /**


### PR DESCRIPTION
Prevents results from being conformed to an object via Inertia rendering where an array is expected.

I observed a bug where entities from different account personalization sections weren't rendering because the frontend Vue code was expecting an array of entity DTO objects but got a nested object of entity DTO objects which broke frontend logic depending on the presence of an array.

Believe this issue may have been introduced with the addition of the localization collection sorting macro and traced it to the construction of the new collection. Looks like all that needed to be done was clean the keys after sorting to prevent Inertia from rendering as a JS object rather than an array.
