### PR TITLE
fix: fix months discrimination

### DIFF
--- a/app/Domains/Vault/ManageLifeMetrics/Web/ViewHelpers/VaultLifeMetricsViewHelper.php
+++ b/app/Domains/Vault/ManageLifeMetrics/Web/ViewHelpers/VaultLifeMetricsViewHelper.php
@@ -59,7 +59,7 @@ class VaultLifeMetricsViewHelper
                 $maxNumberOfEvents = $eventsCounter;
             }
 
-            $date = CarbonImmutable::now()->month($month)->day(1);
+            $date = CarbonImmutable::now()->day(1)->month($month);
             $eventsInMonthCollection->push([
                 'id' => $month,
                 'friendly_name' => DateHelper::formatMonthNumber($date),


### PR DESCRIPTION
Months like Februar are discriminated.
Each end of the month, their Life Metrics won't display, they are not welcome ... because of their size. The `Carbon::now()->month($month)->day(1)` code would just skip Februar (and sometimes April, June, etc.), just because you're currently in a bigger month. This is pure discrimination.
This PR brings back justice in this world.
For all monthkind.